### PR TITLE
Allow merchant to set the % discount for using XMR

### DIFF
--- a/monero/include/monero_payments.php
+++ b/monero/include/monero_payments.php
@@ -148,9 +148,7 @@ public function add_my_currency_symbol( $currency_symbol, $currency ) {
 													'title' => __('% discount for using XMR',  'monero_gateway'),
 													'desc_tip' => __('Provide a descount to your customers for paying privatly with XMR!', 'monero_gateway'),
 													'description' => __(' Want to spread the word about Monero? Offer a little discount! Leave this empty if you do not wish to provide a discount',  'monero_gateway'),
-													'type' => __('checkbox'),
-
-'default' => 'no',
+													'type' => __('text')
 													
 												),
 												'environment' => array(


### PR DESCRIPTION
This sets things back up so that the merchant can set the precise percentage that they want to use as a discount for paying with Monero like in my commit f75790d90836e12a1c596c13f0a2a40c3d4a593e