### PR TITLE
Use view-only wallet in lieu of username/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The easiest way to find a remote node to connect to is to visit [moneroworld.com
 
 * Setup a monero wallet using the monero-wallet-cli tool. If you do not know how to do this you can learn about it at [getmonero.org](https://getmonero.org/resources/user-guides/monero-wallet-cli.html)
 
-* Create a view-only wallet from that wallet for security.
+* [Create a view-only wallet from that wallet for security.](https://monero.stackexchange.com/questions/3178/how-to-create-a-view-only-wallet-for-the-gui/4582#4582)
 
 * Start the Wallet RPC and leave it running in the background. This can be accomplished by running `./monero-wallet-rpc --rpc-bind-port 18082 --disable-rpc-login --log-level 2 --wallet-file /path/viewOnlyWalletFile` where "/path/viewOnlyWalletFile" is the wallet file for your view-only wallet. If you wish to use a remote node you can add the `--daemon-address` flag followed by the address of the node. `--daemon-address node.moneroworld.com:18089` for example.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ The easiest way to find a remote node to connect to is to visit [moneroworld.com
 
 * Setup a monero wallet using the monero-wallet-cli tool. If you do not know how to do this you can learn about it at [getmonero.org](https://getmonero.org/resources/user-guides/monero-wallet-cli.html)
 
-* Start the Wallet RPC and leave it running in the background. This can be accomplished by running `./monero-wallet-rpc --rpc-bind-port 18082 --rpc-login username:password --log-level 2 --wallet-file /path/walletfile` where "username:password" is the username and password that you want to use, seperated by a colon and  "/path/walletfile" is your actual wallet file. If you wish to use a remote node you can add the `--daemon-address` flag followed by the address of the node. `--daemon-address node.moneroworld.com:18089` for example.
+* Create a view-only wallet from that wallet for security.
+
+* Start the Wallet RPC and leave it running in the background. This can be accomplished by running `./monero-wallet-rpc --rpc-bind-port 18082 --disable-rpc-login --log-level 2 --wallet-file /path/viewOnlyWalletFile` where "/path/viewOnlyWalletFile" is the wallet file for your view-only wallet. If you wish to use a remote node you can add the `--daemon-address` flag followed by the address of the node. `--daemon-address node.moneroworld.com:18089` for example.
 
 ## Step 4: Setup Monero Gateway in WooCommerce
 
@@ -58,8 +60,5 @@ The easiest way to find a remote node to connect to is to visit [moneroworld.com
 
 * Click on "Save changes"
 
-## Info on server authentication
-It is reccommended that you specify a username/password with your wallet rpc. This can be done by starting your wallet rpc with `monero-wallet-rpc --rpc-bind-port 18082 --rpc-login username:password --wallet-file /path/walletfile` where "username:password" is the username and password that you want to use, seperated by a colon. Alternatively, you can use the `--restricted-rpc` flag with the wallet rpc like so `./monero-wallet-rpc --testnet --rpc-bind-port 18082 --restricted-rpc --wallet-file wallet/path`.
-
-## Donating Me
+## Donating to the Devs :)
 XMR Address : `44krVcL6TPkANjpFwS2GWvg1kJhTrN7y9heVeQiDJ3rP8iGbCd5GeA4f3c2NKYHC1R4mCgnW7dsUUUae2m9GiNBGT4T8s2X`

--- a/monero/library.php
+++ b/monero/library.php
@@ -9,7 +9,6 @@
  * @author Kacper Rowinski <krowinski@implix.com>
  * http://implix.com
  * Modified to work with monero-rpc wallet by Serhack and cryptochangements
- * This code isn't for Dark Net Markets, please report them to Authority!
  */
 class Monero_Library
 {
@@ -18,8 +17,8 @@ class Monero_Library
         CURLOPT_CONNECTTIMEOUT => 8,
         CURLOPT_TIMEOUT => 8
     );
-    private $username;
-    private $password;
+    protected $host;
+    protected $port;
     private $httpErrors = array(
         400 => '400 Bad Request',
         401 => '401 Unauthorized',
@@ -33,14 +32,14 @@ class Monero_Library
         503 => '503 Service Unavailable'
     );
 
-    public function __construct($pUrl, $pUser, $pPass)
+    public function __construct($pHost, $pPort)
     {
         $this->validate(false === extension_loaded('curl'), 'The curl extension must be loaded to use this class!');
         $this->validate(false === extension_loaded('json'), 'The json extension must be loaded to use this class!');
-
-        $this->url = $pUrl;
-        $this->username = $pUser;
-        $this->password = $pPass;
+        
+        $this->host = $pHost;
+        $this->port = $pPort;
+        $this->url = $pHost . ':' . $pPort . '/json_rpc';
     }
 
     public function validate($pFailed, $pErrMsg)
@@ -166,8 +165,6 @@ class Monero_Library
             throw new RuntimeException('Could\'t initialize a cURL session');
         }
         curl_setopt($ch, CURLOPT_URL, $this->url);
-        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-        curl_setopt($ch, CURLOPT_USERPWD, $this->username . ":" . $this->password);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $pRequest);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-type: application/json'));
@@ -187,7 +184,7 @@ class Monero_Library
         }
         // check for curl error
         if (0 < curl_errno($ch)) {
-            echo 'Unable to connect to ' . $this->url . ' Error: ' . curl_error($ch);
+           echo '[ERROR] Failed to connect to monero-wallet-rpc at ' . $this->host . ' port '. $this->port .'</br>';
         }
         // close the connection
         curl_close($ch);


### PR DESCRIPTION
A view-only wallet should be used instead of username/password for security purposes. This Pull Request also contains some text/error handling improvements.