### PR TITLE
Don't miss blocks if 2 are mined quickly

### DIFF
--- a/monero/include/monero_payments.php
+++ b/monero/include/monero_payments.php
@@ -650,7 +650,7 @@ class Monero_Gateway extends WC_Payment_Gateway
         $output_found;
         $block_index;
         
-        if($difference != 0)
+        if($block_difference != 0)
         {
             $txs_from_block_2 = $tools->get_txs_from_block($bc_height - 1);
             $tx_count_2 = count($txs_from_block_2) - 1;


### PR DESCRIPTION
Sometimes 2 blocks are mined within seconds of each other. This is a fix so that we won't miss them.