### PR TITLE
Re-added Ryo-currency copyright, contributor, and donation address

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017-2018, Monero Integrations
+Copyright (c) 2018, Ryo Currency Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ This will display a badge showing that you accept Monero-currency.
 ## Donations
 
 monero-integrations: 44krVcL6TPkANjpFwS2GWvg1kJhTrN7y9heVeQiDJ3rP8iGbCd5GeA4f3c2NKYHC1R4mCgnW7dsUUUae2m9GiNBGT4T8s2X
+
+ryo-currency: 4A6BQp7do5MTxpCguq1kAS27yMLpbHcf89Ha2a8Shayt2vXkCr6QRpAXr1gLYRV5esfzoK3vLJTm5bDWk5gKmNrT6s6xZep

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Monero WooCommerce Extension ===
-Contributors: Monero Integrations Team
+Contributors: Monero Integrations Team, Ryo Currency Project
 Donate link: http://monerointegrations.com/donate.html
 Tags: monero, woocommerce, integration, payment, merchant, cryptocurrency, accept monero, monero woocommerce
 Requires at least: 4.0


### PR DESCRIPTION
After merging #69, commits 53463e9 and a17af45 remove the copyright and contributor name from the repo. I understand you do not *wan't* my name (or the name of the project I work on) in this codebase, but it was never agreed on that you could remove that copyright notice.