### PR TITLE
modified woocommerce_gateway_icon filter to use two arguments

### DIFF
--- a/include/class-monero-gateway.php
+++ b/include/class-monero-gateway.php
@@ -42,7 +42,7 @@ class Monero_Gateway extends WC_Payment_Gateway
 
     public function get_icon()
     {
-        return apply_filters('woocommerce_gateway_icon', '<img src="'.MONERO_GATEWAY_PLUGIN_URL.'assets/images/monero-icon.png"/>');
+        return apply_filters('woocommerce_gateway_icon', '<img src="'.MONERO_GATEWAY_PLUGIN_URL.'assets/images/monero-icon.png"/>', $this->id);
     }
 
     function __construct($add_action=true)


### PR DESCRIPTION
Users who use this plugin along with the latest version of MyCryptoCheckout 2.24 plugin receive a fatal error. Apply filters function just needs to add a third parameter to fix that. Users who are not using MCC plugin will have no problem.