### PR TITLE
add automated install info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
 
 ## Installing the plugin
 
+### Automatic Method
+
+In the "Add Plugins" section of the WordPress admin UI, search for "monero" and click the Install Now button next to "Monero WooCommerce Extension" by mosu-forge, SerHack.  This will enable auto-updates, but only for official releases, so if you need to work from git master or your local fork, please use the manual method below.
+
+### Manual Method
+
 * Download the plugin from the [releases page](https://github.com/monero-integrations/monerowp) or clone with `git clone https://github.com/monero-integrations/monerowp`
 * Unzip or place the `monero-woocommerce-gateway` folder in the `wp-content/plugins` directory.
 * Activate "Monero Woocommerce Gateway" in your WordPress admin dashboard.


### PR DESCRIPTION
Installing WordPress plugins the "regular" way that receive auto updates is generally better, and is much easier to get working for people with hellish layered developer environments like Win10+WSL2+Docker that make "just copy this file from your web browser" a non-trivial task.  The documentation should at least let people know the simple way is possible.